### PR TITLE
Add support for tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # line-count package
 
+### Description
+
+Fork of Towtow10's line-count atom package with support for `.tsx` file suffix.
+
 ### Usage
 
 Press ctrl-alt-shift-L (line-count:open) to open an editor page showing line counts broken down by file, directory, and file type for all files in the project.
@@ -69,6 +73,7 @@ File suffixes supported are ..
 - .svg
 - .swift
 - .ts
+- .tsx
 - .vb
 - .xml
 - .yaml

--- a/lib/line-count.coffee
+++ b/lib/line-count.coffee
@@ -68,6 +68,7 @@ suffixes = [
   "svg"
   "swift"
   "ts"
+  "tsx"
   "ttslua"
   "vb"
   "vue"
@@ -149,6 +150,10 @@ module.exports =
             type = sfx
             if type == 'ttslua'
               type = 'lua'
+
+            #treat tsx as ts
+            if type == 'tsx'
+              type = 'ts'
 
             try
               counts = sloc code, type


### PR DESCRIPTION
### Description

The original repo works around lack of `.ttslua` support by forcing `sloc` to treat all `.ttslua` as `.lua` files. The strategy is pretty basic but it works well enough. This PR consists in taking the same approach for `.tsx` files.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Testing

Manual tests only