### PR TITLE
Include Liquid & Graphql Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ File suffixes supported are ..
 - .jsx
 - .less
 - .ld
+- .liquid
 - .lua
 - .ls
 - .m

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ File suffixes supported are ..
 - .erl
 - .go
 - .groovy
+- .graphql
 - .gs
 - .h
 - .handlebars

--- a/lib/line-count.coffee
+++ b/lib/line-count.coffee
@@ -23,6 +23,7 @@ suffixes = [
   "go"
   "groovy"
   "gs"
+  "graphql"
   "h"
   "handlebars", "hbs"
   "hpp"

--- a/lib/line-count.coffee
+++ b/lib/line-count.coffee
@@ -41,6 +41,7 @@ suffixes = [
   "jsx"
   "less"
   "ld"
+  "liquid"
   "lua"
   "ls"
   "m"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "line-count",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "line-count",
   "main": "./lib/line-count",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Show line counts for files in projects",
   "activationCommands": {
     "atom-workspace": [


### PR DESCRIPTION
Liquid files are used by Shopify, Siteglide and PlatformOS